### PR TITLE
Add setting metal,ram and metal,itim to overlay generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
+venv
 __pycache__
 *.pyc
 .mypy_cache
-

--- a/targets/arty.py
+++ b/targets/arty.py
@@ -7,7 +7,7 @@ This is a python script for generating RTL testbench Devicetree overlays from th
 for the RTL DUT.
 """
 
-from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash
+from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash, get_rams, set_rams
 
 def generate_overlay(tree, overlay):
     """Generate the overlay"""
@@ -17,3 +17,6 @@ def generate_overlay(tree, overlay):
 
     set_boot_hart(tree, overlay)
     set_stdout(tree, overlay, 115200)
+
+    ram, itim = get_rams(tree)
+    set_rams(overlay, ram, itim)

--- a/targets/hifive.py
+++ b/targets/hifive.py
@@ -7,7 +7,7 @@ This is a python script for generating RTL testbench Devicetree overlays from th
 for the RTL DUT.
 """
 
-from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash
+from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash, get_rams, set_rams
 
 def generate_overlay(tree, overlay):
     """Generate the overlay"""
@@ -26,3 +26,6 @@ def generate_overlay(tree, overlay):
 
     set_boot_hart(tree, overlay)
     set_stdout(tree, overlay, 115200)
+
+    ram, itim = get_rams(tree)
+    set_rams(overlay, ram, itim)

--- a/targets/qemu.py
+++ b/targets/qemu.py
@@ -7,7 +7,7 @@ This is a python script for generating RTL testbench Devicetree overlays from th
 for the RTL DUT.
 """
 
-from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash
+from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash, get_rams, set_rams
 
 def generate_overlay(tree, overlay):
     """Generate the overlay"""

--- a/targets/spike.py
+++ b/targets/spike.py
@@ -7,7 +7,7 @@ This is a python script for generating RTL testbench Devicetree overlays from th
 for the RTL DUT.
 """
 
-from targets.generic import set_boot_hart, set_stdout, set_entry
+from targets.generic import set_boot_hart, set_stdout, set_entry, get_rams, set_rams
 
 def generate_overlay(tree, overlay):
     """Generate the overlay"""
@@ -17,3 +17,6 @@ def generate_overlay(tree, overlay):
 
     set_boot_hart(tree, overlay)
     set_stdout(tree, overlay, 115200)
+
+    ram, itim = get_rams(tree)
+    set_rams(overlay, ram, itim)

--- a/targets/testbench.py
+++ b/targets/testbench.py
@@ -12,7 +12,7 @@ import sys
 import pydevicetree
 
 from targets.generic import PORTS, CAP_SIZE_FOR_VCS
-from targets.generic import number_to_cells, set_boot_hart, set_stdout, set_entry
+from targets.generic import number_to_cells, set_boot_hart, set_stdout, set_entry, get_rams, set_rams
 
 def attach_testrams(tree, overlay):
     """Generate testrams attached to ports in the overlay
@@ -71,3 +71,6 @@ def generate_overlay(tree, overlay):
 
     set_boot_hart(tree, overlay)
     set_stdout(tree, overlay, 100000000)
+
+    ram, itim = get_rams(tree)
+    set_rams(overlay, ram, itim)


### PR DESCRIPTION
For all targets, always set `metal,ram` and `metal,itim` in the overlay. This way the linker script generator no longer needs "strategies", it can always just do exactly what the overlay requests.