### PR TITLE
make writeDevicetreeCustomOverlay a target

### DIFF
--- a/customOverlay.wake
+++ b/customOverlay.wake
@@ -50,7 +50,7 @@ tuple DevicetreeCustomOverlay =
 global def makeDevicetreeCustomOverlay includes chosenNode =
   DevicetreeCustomOverlay includes chosenNode ""
 
-global def writeDevicetreeCustomOverlay file customOverlay =
+global target writeDevicetreeCustomOverlay file customOverlay =
   def makeInclude include =
     "/include/ \"{include}\"\n", Nil
   def includes = mapFlat makeInclude customOverlay.getDevicetreeCustomOverlayIncludes


### PR DESCRIPTION
in wake v0.17 and earlier, `write` is a `def` so writes to the same file would cause a `File output by multiple Jobs` error even if the contents were the same. making `writeDevicetreeCustomOverlay` avoids this