### PR TITLE
Add wake target for installing generator

### DIFF
--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -38,6 +38,16 @@ jobs:
             sifive/environment-blockci:0.3.0 \
             devicetree-overlay-generator/tests/test-wake-api.sh
 
+      - name: 'Run generator install test'
+        run: |
+          set -euo pipefail
+          docker run \
+            --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
+            --workdir="/mnt/workspace" \
+            --rm \
+            sifive/environment-blockci:0.3.0 \
+            devicetree-overlay-generator/tests/test-wake-install.sh
+
       - name: 'Run Custom Overlay Wake API Test'
         run: |
           set -euo pipefail

--- a/build.wake
+++ b/build.wake
@@ -69,3 +69,24 @@ global def runDevicetreeOverlayGenerator options =
 # This allows the python virtualenv to be created prior to running a build
 # with `wake preinstall Unit`.
 publish preinstall = (pythonRequirementsInstaller generatorDir), Nil
+
+#########################################################################
+# installDevicetreeOverlayGenerator allows wake flows to install the
+# overlay generator in customer deliveries and exclude all content which
+# does not directly contribute to the generation of customer BSP content.
+# It takes the following parameter
+#   - installPath: the path to install the generator in
+# For example, if you call `installDevicetreeOverlayGenerator "scripts"`
+# the generator script will be found in
+#   scripts/devicetree-overlay-generator/generate_overlay.py
+#########################################################################
+global target installDevicetreeOverlayGenerator installPath =
+  def generatorSources =
+    source "{here}/README.md",
+    source "{here}/LICENSE",
+    source "{here}/generate_overlay.py",
+    sources "{here}/targets" `.*\.py`
+
+  mkdir installPath,
+
+  map (installIn installPath) generatorSources

--- a/tests/test-wake-install.sh
+++ b/tests/test-wake-install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTALL_PATH="install-path"
+
+wake --init .
+
+wake -v "installDevicetreeOverlayGenerator \"${INSTALL_PATH}\""
+
+>&2 echo "$0: Checking for ${INSTALL_PATH}"
+if [ ! -d ${INSTALL_PATH} ] ; then
+        >&2 echo "$0: ERROR Failed to produce ${INSTALL_PATH}"
+        exit 1
+fi
+
+>&2 echo "$0: Checking for non-empty ${INSTALL_PATH}"
+if [ ! -f ${INSTALL_PATH}/devicetree-overlay-generator/generate_overlay.py ] ; then
+        >&2 echo "$0: ERROR ${INSTALL_PATH} has bad contents"
+        exit 2
+fi


### PR DESCRIPTION
`installDevicetreeOverlayGenerator` allows wake flows to install the overlay generator in customer deliveries and exclude all content which does not directly contribute to the generation of customer BSP content. The README is included to help document the purpose of the generator.