### PR TITLE
Split Arty single srams into ram/itim

### DIFF
--- a/targets/arty.py
+++ b/targets/arty.py
@@ -7,7 +7,9 @@ This is a python script for generating RTL testbench Devicetree overlays from th
 for the RTL DUT.
 """
 
-from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash, get_spi_region, get_rams, set_rams
+from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash, get_spi_region, get_rams, set_rams, set_ram, set_itim
+
+SRAM_SPLIT_MIN_SIZE = 0x10000
 
 def generate_overlay(tree, overlay):
     """Generate the overlay"""
@@ -20,4 +22,19 @@ def generate_overlay(tree, overlay):
     set_stdout(tree, overlay, 115200)
 
     ram, itim = get_rams(tree)
+
+    # If the ram and itim are the same sram node
+    ram_compat = ram.get_field("compatible")
+    if ram_compat is None:
+        ram_compat = ""
+    if ram == itim and "sram" in ram_compat:
+        # get the size of the first tuple
+        size = ram.get_reg()[0][1]
+        # if the size is above the threshold
+        if size >= SRAM_SPLIT_MIN_SIZE:
+            # split the memory into separate ram and itim
+            set_ram(overlay, ram, 0, 0)
+            set_itim(overlay, ram, 0, size / 2)
+            return
+
     set_rams(overlay, ram, itim)


### PR DESCRIPTION
When an Arty target has one sram which is greater than 0x10000 bytes, split it in half and map each half to ram/itim.

Hold until we confirm whether the same is necessary for vcu118.