### PR TITLE
Disable ECC scrubbing on vcu118

### DIFF
--- a/targets/vcu118.py
+++ b/targets/vcu118.py
@@ -17,7 +17,6 @@ def generate_overlay(tree, overlay):
         set_entry(overlay, bootrom, 0, 0)
 
     set_boot_hart(tree, overlay)
-    set_ecc_scrub(tree, overlay)
     set_stdout(tree, overlay, 115200)
 
     ram, itim = get_rams(tree)


### PR DESCRIPTION
In its current form, this scrubs the /memory node, including the running program.