### PR TITLE
CI: update to wake 0.19 and wit action

### DIFF
--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -9,51 +9,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      # $WIT_WORKSPACE path is relative to $GITHUB_WORKSPACE
-      WIT_WORKSPACE: wit-workspace
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Workspace init
+        uses: sifive/wit/actions/init@v0.13.2
+
+      - name: Run Wake API Test
+        uses: sifive/environment-blockci-sifive/actions/shell@0.7.1
         with:
-          path: wit-packages/devicetree-overlay-generator
+          command: devicetree-overlay-generator/tests/test-wake-api.sh
 
-      - name: 'Init Wit Workspace'
-        uses: sifive/wit/actions/wit@v0.12.0
+      - name: Run generator install test
+        uses: sifive/environment-blockci-sifive/actions/shell@0.7.1
         with:
-          command: init
-          arguments: |
-            ${{ env.WIT_WORKSPACE }}
-            -a ./wit-packages/devicetree-overlay-generator
-            -a git@github.com:sifive/environment-blockci-sifive.git::0.3.0
-          force_github_https: true
+          command: devicetree-overlay-generator/tests/test-wake-install.sh
 
-      - name: 'Run Wake API Test'
-        run: |
-          set -euo pipefail
-          docker run \
-            --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
-            --workdir="/mnt/workspace" \
-            --rm \
-            sifive/environment-blockci:0.3.0 \
-            devicetree-overlay-generator/tests/test-wake-api.sh
-
-      - name: 'Run generator install test'
-        run: |
-          set -euo pipefail
-          docker run \
-            --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
-            --workdir="/mnt/workspace" \
-            --rm \
-            sifive/environment-blockci:0.3.0 \
-            devicetree-overlay-generator/tests/test-wake-install.sh
-
-      - name: 'Run Custom Overlay Wake API Test'
-        run: |
-          set -euo pipefail
-          docker run \
-            --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
-            --workdir="/mnt/workspace" \
-            --rm \
-            sifive/environment-blockci:0.3.0 \
-            devicetree-overlay-generator/tests/test-custom-overlay.sh
+      - name: Run Custom Overlay Wake API Test
+        uses: sifive/environment-blockci-sifive/actions/shell@0.7.1
+        with:
+          command: devicetree-overlay-generator/tests/test-custom-overlay.sh

--- a/build.wake
+++ b/build.wake
@@ -31,9 +31,10 @@ global def runDevicetreeOverlayGenerator options =
   def inputs =
     def generatorSources = sources here `.*\.py`
     def dtsSources = topDTSFile, otherDTSFiles
-    generatorSources ++ dtsSources
+    def outputDir = mkdir "{output}/.."
+    outputDir, generatorSources ++ dtsSources
 
-  def outputs = options.getDevicetreeOverlayGeneratorOptionsOutputFile, Nil
+  def output = options.getDevicetreeOverlayGeneratorOptionsOutputFile
 
   def args =
     def output =
@@ -63,7 +64,7 @@ global def runDevicetreeOverlayGenerator options =
   makePlan (pythonCommand "{generatorDir}/generate_overlay.py" args) inputs
   | addPlanRelativePath "PYTHONPATH" generatorDir
   | addPythonRequirementsEnv generatorDir
-  | setPlanFnOutputs (\_ outputs)
+  | setPlanFnOutputs (\_ output, Nil)
   | runJob
 
 # This allows the python virtualenv to be created prior to running a build

--- a/tests/test-custom-overlay.sh
+++ b/tests/test-custom-overlay.sh
@@ -4,13 +4,11 @@ set -euo pipefail
 
 OUTPUT_PATH="build/devicetree-overlay-generator/customOverlay.dts"
 
-wake --init .
-
-wake -v "writeDevicetreeCustomOverlay \"${OUTPUT_PATH}\" \
-                                      (makeDevicetreeCustomOverlay (\"core.dts\", Nil) \
-                                                                   (makeDevicetreeChosenNode (makeDevicetreeChosenMemoryEntry \"/soc/bootrom@20000000\" 0 0) \
-                                                                                             (makeDevicetreeChosenMemoryRam \"/soc/sram@80000000\" 0 0) \
-                                                                                             None))"
+wake -vx "writeDevicetreeCustomOverlay \"${OUTPUT_PATH}\" \
+                                       (makeDevicetreeCustomOverlay (\"core.dts\", Nil) \
+                                                                    (makeDevicetreeChosenNode (makeDevicetreeChosenMemoryEntry \"/soc/bootrom@20000000\" 0 0) \
+                                                                                              (makeDevicetreeChosenMemoryRam \"/soc/sram@80000000\" 0 0) \
+                                                                                              None))"
 
 >&2 echo "$0: Checking for ${OUTPUT_PATH}"
 if [ ! -f ${OUTPUT_PATH} ] ; then

--- a/tests/test-wake-api.sh
+++ b/tests/test-wake-api.sh
@@ -7,9 +7,7 @@ SPIKE_DTS_DIR=${SCRIPT_DIR}/spike
 
 OUTPUT_PATH="build/devicetree-overlay-generator/design.dts"
 
-wake --init .
-
-wake -v "runDevicetreeOverlayGenerator (makeDevicetreeOverlayGeneratorOptions (source \"${SPIKE_DTS_DIR}/core.dts\") Nil \"spike\" \"${OUTPUT_PATH}\")"
+wake -vx "runDevicetreeOverlayGenerator (makeDevicetreeOverlayGeneratorOptions (source \"${SPIKE_DTS_DIR}/core.dts\") Nil \"spike\" \"${OUTPUT_PATH}\")"
 
 >&2 echo "$0: Checking for ${OUTPUT_PATH}"
 if [ ! -f ${OUTPUT_PATH} ] ; then

--- a/tests/test-wake-install.sh
+++ b/tests/test-wake-install.sh
@@ -4,9 +4,7 @@ set -euo pipefail
 
 INSTALL_PATH="install-path"
 
-wake --init .
-
-wake -v "installDevicetreeOverlayGenerator \"${INSTALL_PATH}\""
+wake -vx "installDevicetreeOverlayGenerator \"${INSTALL_PATH}\""
 
 >&2 echo "$0: Checking for ${INSTALL_PATH}"
 if [ ! -d ${INSTALL_PATH} ] ; then

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "a2e36e2c523c66d499810bd52a2956623e2066f6",
+        "commit": "e135f6a013d830f34aeb1a9542f42c0aabc80813",
         "name": "api-languages-sifive",
         "source": "git@github.com:sifive/api-languages-sifive.git"
     }


### PR DESCRIPTION
I updated the tests/ scripts to use `-x` for wake 0.19.0. I otherwise left them alone.
I bumped api-languages-sifive for its 0.19.0 support.
I fixed a bug in build.wake whereby it did not create the output directory before running python.
I switched the CI to using the new wit/init action.