### PR TITLE
Use wake 'here' to make install path source location flexible

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -70,7 +70,7 @@ global def runDevicetreeOverlayGenerator options =
 # with `wake preinstall Unit`.
 publish preinstall = (pythonRequirementsInstaller generatorDir), Nil
 
-#########################################################################
+
 # installDevicetreeOverlayGenerator allows wake flows to install the
 # overlay generator in customer deliveries and exclude all content which
 # does not directly contribute to the generation of customer BSP content.
@@ -86,7 +86,9 @@ global target installDevicetreeOverlayGenerator installPath =
     source "{here}/LICENSE",
     source "{here}/generate_overlay.py",
     sources "{here}/targets" `.*\.py`
-
+  def installWithStructure dir file =
+    def oneDown = simplify "{here}/.."
+    def into = "{dir}/{relative oneDown file.getPathName}"
+    installAs into file
   mkdir installPath,
-
-  map (installIn installPath) generatorSources
+  map (installWithStructure installPath) generatorSources

--- a/build.wake
+++ b/build.wake
@@ -70,7 +70,7 @@ global def runDevicetreeOverlayGenerator options =
 # with `wake preinstall Unit`.
 publish preinstall = (pythonRequirementsInstaller generatorDir), Nil
 
-
+#########################################################################
 # installDevicetreeOverlayGenerator allows wake flows to install the
 # overlay generator in customer deliveries and exclude all content which
 # does not directly contribute to the generation of customer BSP content.


### PR DESCRIPTION
`installIn` is defined as 
```
export def installIn dir file =
  installAs "{dir}/{file.getPathName}" file
```

When used with Wit, the `getPathName` would include only the repository name, for example:
```
installIn "builddir" pathToSomeFile -> builddir/devicetree-overlay-generator/somefile.sh
```
When the wake rule is used via git submodules a longer path is inserted, for example
```
installIn "builddir" pathToSomeFile -> builddir/freedom-e-sdk/software/devicetree-overlay-generator/somefile.sh
```
This PR aims to resolve the inconsistency by using `here/..` to capture the repository name directly, thus preserving the paths in `builddir`