### PR TITLE
Use ccache instead of ddr on HiFive platform

### DIFF
--- a/targets/generic.py
+++ b/targets/generic.py
@@ -109,6 +109,14 @@ def set_rams(overlay, ram, itim):
     if ram:
         set_ram(overlay, ram, 0, 0)
 
+def set_rams(overlay, ram, itim, region):
+    """Set the metal,ram and metal,itim properties"""
+    if itim:
+        set_itim(overlay, itim, region, 0)
+    if ram:
+        set_ram(overlay, ram, region, 0)
+
+
 def set_itim(overlay, node, tuple_index, offset):
     """Set itim in overlay"""
     chosen = overlay.get_by_path("/chosen")
@@ -145,6 +153,20 @@ def set_ecc_scrub(tree, overlay):
         ecc_scrub = 0
     chosen.properties.append(pydevicetree.Property.from_dts("metal,eccscrub = <%d>;" % \
                                                             ecc_scrub))
+
+def get_ccache(tree):
+    """Get ccache node"""
+    ccache = tree.match("sifive,ccache0")
+    if len(ccache) > 0:
+        return ccache[0]
+
+def get_ccache_region(ccache_node):
+    """Get which reg tuple should be used for memory"""
+    tuples = ccache_node.get_reg().tuples
+    for i, tup in enumerate(tuples):
+        if tup[2] == "sideband":
+            return i
+    return 0
 
 def get_spi_flash(tree):
     """Get the SPI Flash node"""

--- a/targets/hifive.py
+++ b/targets/hifive.py
@@ -7,7 +7,9 @@ This is a python script for generating RTL testbench Devicetree overlays from th
 for the RTL DUT.
 """
 
-from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash, get_spi_region, get_rams, set_rams
+from targets.generic import set_boot_hart, set_stdout, set_entry, get_spi_flash, get_spi_region, get_rams, set_rams, get_ccache, get_ccache_region, set_ram, set_itim
+
+#def attach_testrams(tree, overlay):
 
 def generate_overlay(tree, overlay):
     """Generate the overlay"""
@@ -28,5 +30,11 @@ def generate_overlay(tree, overlay):
     set_boot_hart(tree, overlay)
     set_stdout(tree, overlay, 115200)
 
-    ram, itim = get_rams(tree)
-    set_rams(overlay, ram, itim)
+    if model == "sifive,hifive-unmatched-a00" or \
+       model == "sifive,hifive-unleashed-a00":
+        ram = itim = ccache = get_ccache(tree)
+        region = get_ccache_region(ccache)
+        set_rams(overlay, ram, itim, region)
+    else:
+        ram, itim = get_rams(tree)
+        set_rams(overlay, ram, itim)


### PR DESCRIPTION
DDR needs to be initialized before use, so we should use ccache instead of ddr on HiFive platform to make following things work:
 1. openocd: point -work-area-phys to ccache
 2. linker script: put data section into ccache rather than ddr
