### PR TITLE
Fix set_rams() to use region=0 default

### DIFF
--- a/targets/generic.py
+++ b/targets/generic.py
@@ -102,14 +102,7 @@ def get_rams(tree):
 
     return (ram, itim)
 
-def set_rams(overlay, ram, itim):
-    """Set the metal,ram and metal,itim properties"""
-    if itim:
-        set_itim(overlay, itim, 0, 0)
-    if ram:
-        set_ram(overlay, ram, 0, 0)
-
-def set_rams(overlay, ram, itim, region):
+def set_rams(overlay, ram, itim, region=0):
     """Set the metal,ram and metal,itim properties"""
     if itim:
         set_itim(overlay, itim, region, 0)


### PR DESCRIPTION
A recent update to `generic.py` added a second copy of `set_rams` with a new `region` parameter, rather than using a Python default argument value of `region=0`, thereby replacing the original function unintentionally.  This caused a missing argument exception for targets that don't have a region, which this PR fixes.