### PR TITLE
Fix ccache node is unavailable due to compatible

### DIFF
--- a/targets/generic.py
+++ b/targets/generic.py
@@ -159,6 +159,10 @@ def get_ccache(tree):
     ccache = tree.match("sifive,ccache0")
     if len(ccache) > 0:
         return ccache[0]
+    ccache = tree.match("cache")
+    if len(ccache) > 0:
+        return ccache[0]
+    return None
 
 def get_ccache_region(ccache_node):
     """Get which reg tuple should be used for memory"""


### PR DESCRIPTION
We get the ccache node by compatible "sifive,ccache0" in hifive target, but Unleashed's compatible string of ccache node is "sifive,fu540-c000,l2" and "cache", so it would get None on Unleashed. We add secondary condition  by matching "cache" compatible to find ccache node, because "cache" is also present in Unmatched's compatible of ccache node.